### PR TITLE
Add mobile editor with title validation and duplicate warning

### DIFF
--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -92,6 +92,9 @@ export default function MobileEditorLayout() {
   });
   const { createQuiz, getQuizzesByDocument, getAllQuizzes } = useQuiz();
   const [isEditingContent, setIsEditingContent] = useState(false);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [tempTitle, setTempTitle] = useState('');
+  const [showDuplicateWarning, setShowDuplicateWarning] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
   const [previewContent, setPreviewContent] = useState('');
 

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -23,7 +23,7 @@ import { useQuiz } from '../contexts/QuizContext';
 
 interface Document {
   id: string;
-  name: string;
+  title: string;
   content: string;
   createdAt: Date;
 }
@@ -31,22 +31,20 @@ interface Document {
 const initialDocuments: Document[] = [
   {
     id: '1',
-    name: 'English 2',
+    title: 'English 2',
     content: 'Welcome to English 2! Start writing your notes here...',
     createdAt: new Date('2024-01-15')
   },
   {
     id: '2',
-    name: 'English 3',
+    title: 'English 3',
     content: 'Welcome to English 3! This is your study space.',
     createdAt: new Date('2024-01-16')
   },
   {
     id: '3',
-    name: 'English 4',
-    content: `# English 4
-
-Companies often **hedge** against currency fluctuations to protect their profits [hedge is an investment that is made to reduce the risk of adverse price movements in an asset]
+    title: 'English 4',
+    content: `Companies often **hedge** against currency fluctuations to protect their profits [hedge is an investment that is made to reduce the risk of adverse price movements in an asset]
 
 Investors often **hedge** their bets by buying different types of assets [To reduce or protect against the risk of loss, especially in finance.]
 

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -1,25 +1,25 @@
-import React, { useState, useEffect, useRef } from 'react';
-import { useNavigate } from 'react-router-dom';
-import { 
-  ChevronLeft, 
-  FileText, 
-  Plus, 
-  Menu, 
-  X, 
-  Settings, 
-  Loader2, 
+import React, { useState, useEffect, useRef } from "react";
+import { useNavigate } from "react-router-dom";
+import {
+  ChevronLeft,
+  FileText,
+  Plus,
+  Menu,
+  X,
+  Settings,
+  Loader2,
   Search,
   Bookmark,
   MoreVertical,
   Home,
   Layers,
   PenTool,
-  Grid
-} from 'lucide-react';
-import { Button } from './ui/button';
-import SettingsModal, { AppSettings } from './SettingsModal';
-import { getLLMService } from '../services/llmService';
-import { useQuiz } from '../contexts/QuizContext';
+  Grid,
+} from "lucide-react";
+import { Button } from "./ui/button";
+import SettingsModal, { AppSettings } from "./SettingsModal";
+import { getLLMService } from "../services/llmService";
+import { useQuiz } from "../contexts/QuizContext";
 
 interface Document {
   id: string;
@@ -30,20 +30,20 @@ interface Document {
 
 const initialDocuments: Document[] = [
   {
-    id: '1',
-    title: 'English 2',
-    content: 'Welcome to English 2! Start writing your notes here...',
-    createdAt: new Date('2024-01-15')
+    id: "1",
+    title: "English 2",
+    content: "Welcome to English 2! Start writing your notes here...",
+    createdAt: new Date("2024-01-15"),
   },
   {
-    id: '2',
-    title: 'English 3',
-    content: 'Welcome to English 3! This is your study space.',
-    createdAt: new Date('2024-01-16')
+    id: "2",
+    title: "English 3",
+    content: "Welcome to English 3! This is your study space.",
+    createdAt: new Date("2024-01-16"),
   },
   {
-    id: '3',
-    title: 'English 4',
+    id: "3",
+    title: "English 4",
     content: `Companies often **hedge** against currency fluctuations to protect their profits [hedge is an investment that is made to reduce the risk of adverse price movements in an asset]
 
 Investors often **hedge** their bets by buying different types of assets [To reduce or protect against the risk of loss, especially in finance.]
@@ -63,43 +63,49 @@ It's illegal to **falsify** your resume by lying about your qualifications [alte
 A company conducting **due diligence** before acquiring another business to check its finances and legal liabilities. [careful, thorough, and systematic effort or research done to gather information, assess risks, or verify facts before making a decision]
 
 The company took on significant **liability** after the accident, as they had to pay for damages. [Legal or financial responsibility for something, especially for`,
-    createdAt: new Date('2024-01-17')
-  }
+    createdAt: new Date("2024-01-17"),
+  },
 ];
 
 export default function MobileEditorLayout() {
   const navigate = useNavigate();
   const [documents, setDocuments] = useState<Document[]>(initialDocuments);
-  const [selectedDocumentId, setSelectedDocumentId] = useState<string>('3');
-  const [selectedText, setSelectedText] = useState('');
+  const [selectedDocumentId, setSelectedDocumentId] = useState<string>("3");
+  const [selectedText, setSelectedText] = useState("");
   const [documentsDrawerOpen, setDocumentsDrawerOpen] = useState(false);
   const [quizDrawerOpen, setQuizDrawerOpen] = useState(false);
   const [searchDrawerOpen, setSearchDrawerOpen] = useState(false);
-  const [searchQuery, setSearchQuery] = useState('');
-  const [searchResults, setSearchResults] = useState<{doc: Document, matches: string[]}[]>([]);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [searchResults, setSearchResults] = useState<
+    { doc: Document; matches: string[] }[]
+  >([]);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [isGeneratingQuiz, setIsGeneratingQuiz] = useState(false);
-  const [generatingType, setGeneratingType] = useState<string>('');
+  const [generatingType, setGeneratingType] = useState<string>("");
   const [settings, setSettings] = useState<AppSettings>({
     general: {
-      languageLevel: 'cet4'
+      languageLevel: "cet4",
     },
     llm: {
-      apiKey: 'AIzaSyCNDJgpRcdDiEVSNomjIMTW1yNWjX7K6P0',
-      provider: 'gemini',
-      model: 'gemini-2.0-flash-exp'
-    }
+      apiKey: "AIzaSyCNDJgpRcdDiEVSNomjIMTW1yNWjX7K6P0",
+      provider: "gemini",
+      model: "gemini-2.0-flash-exp",
+    },
   });
   const { createQuiz, getQuizzesByDocument, getAllQuizzes } = useQuiz();
   const [isEditingContent, setIsEditingContent] = useState(false);
   const [isEditingTitle, setIsEditingTitle] = useState(false);
-  const [tempTitle, setTempTitle] = useState('');
+  const [tempTitle, setTempTitle] = useState("");
   const [showDuplicateWarning, setShowDuplicateWarning] = useState(false);
   const [showPreview, setShowPreview] = useState(false);
-  const [previewContent, setPreviewContent] = useState('');
+  const [previewContent, setPreviewContent] = useState("");
 
-  const selectedDocument = documents.find(doc => doc.id === selectedDocumentId);
-  const documentQuizzes = selectedDocument ? getQuizzesByDocument(selectedDocument.id) : [];
+  const selectedDocument = documents.find(
+    (doc) => doc.id === selectedDocumentId,
+  );
+  const documentQuizzes = selectedDocument
+    ? getQuizzesByDocument(selectedDocument.id)
+    : [];
   const allQuizzes = getAllQuizzes();
 
   // Function to get display name for document
@@ -109,9 +115,9 @@ export default function MobileEditorLayout() {
 
   // Check if title already exists in other documents
   const isTitleDuplicate = (title: string, excludeId?: string): boolean => {
-    return documents.some(doc =>
-      doc.title.toLowerCase() === title.toLowerCase() &&
-      doc.id !== excludeId
+    return documents.some(
+      (doc) =>
+        doc.title.toLowerCase() === title.toLowerCase() && doc.id !== excludeId,
     );
   };
 
@@ -139,33 +145,31 @@ export default function MobileEditorLayout() {
     }
 
     // Update document title
-    setDocuments(prev =>
-      prev.map(doc =>
-        doc.id === selectedDocument.id
-          ? { ...doc, title: trimmedTitle }
-          : doc
-      )
+    setDocuments((prev) =>
+      prev.map((doc) =>
+        doc.id === selectedDocument.id ? { ...doc, title: trimmedTitle } : doc,
+      ),
     );
 
     setIsEditingTitle(false);
-    setTempTitle('');
+    setTempTitle("");
   };
 
   // Cancel title editing
   const cancelTitleEditing = () => {
     setIsEditingTitle(false);
-    setTempTitle('');
+    setTempTitle("");
     setShowDuplicateWarning(false);
   };
 
   const handleQuizToolClick = async (toolId: string) => {
     if (!selectedText) {
-      alert('Please select some text first to generate a quiz!');
+      alert("Please select some text first to generate a quiz!");
       return;
     }
 
     if (!settings.llm.apiKey) {
-      alert('Please configure your LLM API key in settings first!');
+      alert("Please configure your LLM API key in settings first!");
       setSettingsOpen(true);
       return;
     }
@@ -178,31 +182,52 @@ export default function MobileEditorLayout() {
       const llmService = getLLMService(settings);
 
       switch (toolId) {
-        case 'flashcard': {
+        case "flashcard": {
           const flashcards = await llmService.generateFlashCards(selectedText);
-          createQuiz('flashcard', `Flashcards - ${getDocumentDisplayName(selectedDocument!)}`, selectedText, flashcards, selectedDocument!.id);
-          navigate('/quiz/flashcard');
+          createQuiz(
+            "flashcard",
+            `Flashcards - ${getDocumentDisplayName(selectedDocument!)}`,
+            selectedText,
+            flashcards,
+            selectedDocument!.id,
+          );
+          navigate("/quiz/flashcard");
           break;
         }
-        case 'multiple-choice': {
-          const questions = await llmService.generateMultipleChoice(selectedText);
-          createQuiz('multiple-choice', `Multiple Choice - ${getDocumentDisplayName(selectedDocument!)}`, selectedText, questions, selectedDocument!.id);
-          navigate('/quiz/multiple-choice');
+        case "multiple-choice": {
+          const questions =
+            await llmService.generateMultipleChoice(selectedText);
+          createQuiz(
+            "multiple-choice",
+            `Multiple Choice - ${getDocumentDisplayName(selectedDocument!)}`,
+            selectedText,
+            questions,
+            selectedDocument!.id,
+          );
+          navigate("/quiz/multiple-choice");
           break;
         }
-        case 'short-writing': {
+        case "short-writing": {
           const tasks = await llmService.generateWritingTasks(selectedText);
-          createQuiz('short-writing', `Writing Tasks - ${getDocumentDisplayName(selectedDocument!)}`, selectedText, tasks, selectedDocument!.id);
-          navigate('/quiz/short-writing');
+          createQuiz(
+            "short-writing",
+            `Writing Tasks - ${getDocumentDisplayName(selectedDocument!)}`,
+            selectedText,
+            tasks,
+            selectedDocument!.id,
+          );
+          navigate("/quiz/short-writing");
           break;
         }
       }
     } catch (error) {
-      console.error('Error generating quiz:', error);
-      alert(`Failed to generate quiz: ${error instanceof Error ? error.message : 'Unknown error'}`);
+      console.error("Error generating quiz:", error);
+      alert(
+        `Failed to generate quiz: ${error instanceof Error ? error.message : "Unknown error"}`,
+      );
     } finally {
       setIsGeneratingQuiz(false);
-      setGeneratingType('');
+      setGeneratingType("");
     }
   };
 
@@ -214,11 +239,13 @@ export default function MobileEditorLayout() {
   };
 
   const handleAddDocument = () => {
-    const newId = (Math.max(...documents.map(d => parseInt(d.id))) + 1).toString();
+    const newId = (
+      Math.max(...documents.map((d) => parseInt(d.id))) + 1
+    ).toString();
 
     // Generate unique title
-    let baseTitle = 'New Document';
-    let titleSuffix = '';
+    let baseTitle = "New Document";
+    let titleSuffix = "";
     let counter = 1;
 
     while (isTitleDuplicate(baseTitle + titleSuffix)) {
@@ -231,34 +258,34 @@ export default function MobileEditorLayout() {
     const newDocument: Document = {
       id: newId,
       title: uniqueTitle,
-      content: 'Start writing your content here...',
-      createdAt: new Date()
+      content: "Start writing your content here...",
+      createdAt: new Date(),
     };
 
-    setDocuments(prev => [...prev, newDocument]);
+    setDocuments((prev) => [...prev, newDocument]);
     setSelectedDocumentId(newId);
     setDocumentsDrawerOpen(false);
   };
 
   const handleDeleteDocument = (docId: string) => {
     if (documents.length <= 1) {
-      alert('You must have at least one document.');
+      alert("You must have at least one document.");
       return;
     }
-    
-    if (confirm('Are you sure you want to delete this document?')) {
-      setDocuments(prev => prev.filter(doc => doc.id !== docId));
-      
+
+    if (confirm("Are you sure you want to delete this document?")) {
+      setDocuments((prev) => prev.filter((doc) => doc.id !== docId));
+
       if (selectedDocumentId === docId) {
-        const remainingDocs = documents.filter(doc => doc.id !== docId);
-        setSelectedDocumentId(remainingDocs[0]?.id || '');
+        const remainingDocs = documents.filter((doc) => doc.id !== docId);
+        setSelectedDocumentId(remainingDocs[0]?.id || "");
       }
     }
   };
 
   const handleDocumentSelect = (docId: string) => {
     setSelectedDocumentId(docId);
-    setSelectedText('');
+    setSelectedText("");
     setDocumentsDrawerOpen(false);
     setSearchDrawerOpen(false);
   };
@@ -270,15 +297,18 @@ export default function MobileEditorLayout() {
       return;
     }
 
-    const results: {doc: Document, matches: string[]}[] = [];
-    documents.forEach(doc => {
+    const results: { doc: Document; matches: string[] }[] = [];
+    documents.forEach((doc) => {
       const content = doc.content.toLowerCase();
       const searchTerm = query.toLowerCase();
 
-      if (content.includes(searchTerm) || getDocumentDisplayName(doc).toLowerCase().includes(searchTerm)) {
-        const lines = doc.content.split('\n');
+      if (
+        content.includes(searchTerm) ||
+        getDocumentDisplayName(doc).toLowerCase().includes(searchTerm)
+      ) {
+        const lines = doc.content.split("\n");
         const matches = lines
-          .filter(line => line.toLowerCase().includes(searchTerm))
+          .filter((line) => line.toLowerCase().includes(searchTerm))
           .slice(0, 3); // Limit to 3 matches per document
 
         results.push({ doc, matches });
@@ -290,41 +320,54 @@ export default function MobileEditorLayout() {
 
   const highlightSearchTerm = (text: string, query: string) => {
     if (!query) return text;
-    const regex = new RegExp(`(${query})`, 'gi');
+    const regex = new RegExp(`(${query})`, "gi");
     return text.replace(regex, '<mark class="bg-yellow-300">$1</mark>');
   };
 
   const handleContentChange = (newContent: string) => {
     if (selectedDocument) {
-      setDocuments(prev => 
-        prev.map(doc => 
-          doc.id === selectedDocument.id 
+      setDocuments((prev) =>
+        prev.map((doc) =>
+          doc.id === selectedDocument.id
             ? { ...doc, content: newContent }
-            : doc
-        )
+            : doc,
+        ),
       );
     }
   };
 
   const renderMobileMarkdownContent = (content: string) => {
     return content
-      .split('\n')
+      .split("\n")
       .map((line, index) => {
         // Skip H1 headers as title is now handled separately
-        if (line.startsWith('# ')) {
+        if (line.startsWith("# ")) {
           return null;
         }
-        if (line.startsWith('## ')) {
-          return <h2 key={index} className="text-xl font-semibold mb-4 mt-6 text-gray-900">{line.substring(3)}</h2>;
+        if (line.startsWith("## ")) {
+          return (
+            <h2
+              key={index}
+              className="text-xl font-semibold mb-4 mt-6 text-gray-900"
+            >
+              {line.substring(3)}
+            </h2>
+          );
         }
-        if (line.trim() === '') {
+        if (line.trim() === "") {
           return <div key={index} className="mb-4"></div>;
         }
 
         // Handle mobile-optimized markdown formatting
         const processedLine = line
-          .replace(/\*\*(.*?)\*\*/g, '<span class="bg-yellow-200 px-1 py-0.5 rounded font-medium text-gray-900">$1</span>')
-          .replace(/\[([^\]]+)\]/g, '<span class="text-purple-600 text-sm block mt-1 leading-relaxed">[$1]</span>');
+          .replace(
+            /\*\*(.*?)\*\*/g,
+            '<span class="bg-yellow-200 px-1 py-0.5 rounded font-medium text-gray-900">$1</span>',
+          )
+          .replace(
+            /\[([^\]]+)\]/g,
+            '<span class="text-purple-600 text-sm block mt-1 leading-relaxed">[$1]</span>',
+          );
 
         return (
           <p
@@ -349,17 +392,15 @@ export default function MobileEditorLayout() {
         >
           <ChevronLeft className="w-5 h-5 text-gray-600" />
         </Button>
-        
+
         <h1 className="text-lg font-medium text-gray-900 truncate mx-4">
-          {selectedDocument ? getDocumentDisplayName(selectedDocument) : 'Documents'}
+          {selectedDocument
+            ? getDocumentDisplayName(selectedDocument)
+            : "Documents"}
         </h1>
-        
+
         <div className="flex items-center space-x-2">
-          <Button
-            variant="ghost"
-            size="sm"
-            className="p-2"
-          >
+          <Button variant="ghost" size="sm" className="p-2">
             <Bookmark className="w-5 h-5 text-gray-600" />
           </Button>
           <Button
@@ -393,18 +434,18 @@ export default function MobileEditorLayout() {
               onDoubleClick={() => setIsEditingContent(true)}
               onDragOver={(e) => {
                 e.preventDefault();
-                e.dataTransfer.dropEffect = 'copy';
+                e.dataTransfer.dropEffect = "copy";
               }}
               onDrop={(e) => {
                 e.preventDefault();
-                const quizData = e.dataTransfer.getData('quiz');
+                const quizData = e.dataTransfer.getData("quiz");
                 if (quizData) {
                   try {
                     const quiz = JSON.parse(quizData);
                     setPreviewContent(quiz.sourceText);
                     setShowPreview(true);
                   } catch (error) {
-                    console.error('Error parsing dropped quiz data:', error);
+                    console.error("Error parsing dropped quiz data:", error);
                   }
                 }
               }}
@@ -417,9 +458,9 @@ export default function MobileEditorLayout() {
                   onChange={(e) => setTempTitle(e.target.value)}
                   onBlur={saveTitleChanges}
                   onKeyDown={(e) => {
-                    if (e.key === 'Enter') {
+                    if (e.key === "Enter") {
                       saveTitleChanges();
-                    } else if (e.key === 'Escape') {
+                    } else if (e.key === "Escape") {
                       cancelTitleEditing();
                     }
                   }}
@@ -440,13 +481,15 @@ export default function MobileEditorLayout() {
               {showPreview ? (
                 <>
                   <div className="mb-4 p-3 bg-orange-50 border border-orange-200 rounded-lg">
-                    <div className="font-medium text-orange-800 mb-2">📖 Quiz Source Preview</div>
+                    <div className="font-medium text-orange-800 mb-2">
+                      📖 Quiz Source Preview
+                    </div>
                     <Button
                       size="sm"
                       variant="outline"
                       onClick={() => {
                         setShowPreview(false);
-                        setPreviewContent('');
+                        setPreviewContent("");
                       }}
                     >
                       Return to Document
@@ -532,26 +575,34 @@ export default function MobileEditorLayout() {
                 <X className="w-5 h-5" />
               </Button>
             </div>
-            
+
             <div className="overflow-y-auto flex-1 p-4">
               <div className="space-y-2">
                 {documents.map((doc) => (
                   <div
                     key={doc.id}
                     className={`flex items-center justify-between p-4 rounded-lg cursor-pointer transition-colors ${
-                      selectedDocumentId === doc.id 
-                        ? 'bg-blue-50 border border-blue-200' 
-                        : 'bg-gray-50 hover:bg-gray-100'
+                      selectedDocumentId === doc.id
+                        ? "bg-blue-50 border border-blue-200"
+                        : "bg-gray-50 hover:bg-gray-100"
                     }`}
                     onClick={() => handleDocumentSelect(doc.id)}
                   >
                     <div className="flex items-center flex-1 min-w-0">
-                      <FileText className={`w-5 h-5 mr-3 flex-shrink-0 ${
-                        selectedDocumentId === doc.id ? 'text-blue-500' : 'text-gray-500'
-                      }`} />
+                      <FileText
+                        className={`w-5 h-5 mr-3 flex-shrink-0 ${
+                          selectedDocumentId === doc.id
+                            ? "text-blue-500"
+                            : "text-gray-500"
+                        }`}
+                      />
                       <div className="min-w-0 flex-1">
-                        <div className="font-medium text-gray-900 truncate">{getDocumentDisplayName(doc)}</div>
-                        <div className="text-sm text-gray-500">{doc.createdAt.toLocaleDateString()}</div>
+                        <div className="font-medium text-gray-900 truncate">
+                          {getDocumentDisplayName(doc)}
+                        </div>
+                        <div className="text-sm text-gray-500">
+                          {doc.createdAt.toLocaleDateString()}
+                        </div>
                       </div>
                     </div>
                     {documents.length > 1 && (
@@ -570,7 +621,7 @@ export default function MobileEditorLayout() {
                   </div>
                 ))}
               </div>
-              
+
               <Button
                 variant="outline"
                 className="w-full mt-4"
@@ -623,13 +674,19 @@ export default function MobileEditorLayout() {
                       className="p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors"
                       onClick={() => handleDocumentSelect(doc.id)}
                     >
-                      <div className="font-medium text-gray-900 mb-2">{getDocumentDisplayName(doc)}</div>
+                      <div className="font-medium text-gray-900 mb-2">
+                        {getDocumentDisplayName(doc)}
+                      </div>
                       {matches.map((match, index) => (
                         <div
                           key={index}
                           className="text-sm text-gray-600 mb-1 leading-relaxed"
                           dangerouslySetInnerHTML={{
-                            __html: highlightSearchTerm(match.substring(0, 100) + (match.length > 100 ? '...' : ''), searchQuery)
+                            __html: highlightSearchTerm(
+                              match.substring(0, 100) +
+                                (match.length > 100 ? "..." : ""),
+                              searchQuery,
+                            ),
                           }}
                         />
                       ))}
@@ -653,13 +710,15 @@ export default function MobileEditorLayout() {
       {/* Quiz Tools Drawer */}
       {quizDrawerOpen && (
         <>
-          <div 
+          <div
             className="fixed inset-0 bg-black bg-opacity-50 z-30"
             onClick={() => setQuizDrawerOpen(false)}
           />
           <div className="fixed bottom-0 left-0 right-0 bg-white rounded-t-xl z-40 max-h-[80vh] overflow-hidden">
             <div className="flex items-center justify-between p-4 border-b border-gray-200">
-              <h2 className="text-lg font-semibold text-gray-900">Quiz Tools</h2>
+              <h2 className="text-lg font-semibold text-gray-900">
+                Quiz Tools
+              </h2>
               <Button
                 variant="ghost"
                 size="sm"
@@ -668,79 +727,106 @@ export default function MobileEditorLayout() {
                 <X className="w-5 h-5" />
               </Button>
             </div>
-            
+
             <div className="overflow-y-auto max-h-[60vh] p-4">
               {selectedText ? (
                 <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg mb-4">
-                  <div className="font-medium text-blue-800 mb-1">Selected text:</div>
-                  <div className="text-blue-700 text-sm">"{selectedText.substring(0, 100)}{selectedText.length > 100 ? '...' : '"'}</div>
+                  <div className="font-medium text-blue-800 mb-1">
+                    Selected text:
+                  </div>
+                  <div className="text-blue-700 text-sm">
+                    "{selectedText.substring(0, 100)}
+                    {selectedText.length > 100 ? "..." : '"'}
+                  </div>
                 </div>
               ) : (
                 <div className="p-3 bg-gray-50 border border-gray-200 rounded-lg mb-4">
-                  <div className="text-gray-600 text-sm">Select text in the document to generate quizzes</div>
+                  <div className="text-gray-600 text-sm">
+                    Select text in the document to generate quizzes
+                  </div>
                 </div>
               )}
 
               <div className="space-y-3">
-                <div 
+                <div
                   className={`p-4 rounded-lg border-2 border-blue-200 bg-blue-50 cursor-pointer hover:shadow-md transition-all ${
-                    isGeneratingQuiz && generatingType === 'flashcard' ? 'opacity-50 pointer-events-none' : ''
+                    isGeneratingQuiz && generatingType === "flashcard"
+                      ? "opacity-50 pointer-events-none"
+                      : ""
                   }`}
-                  onClick={() => handleQuizToolClick('flashcard')}
+                  onClick={() => handleQuizToolClick("flashcard")}
                 >
                   <div className="flex items-center space-x-3">
-                    {isGeneratingQuiz && generatingType === 'flashcard' ? (
+                    {isGeneratingQuiz && generatingType === "flashcard" ? (
                       <Loader2 className="w-6 h-6 animate-spin text-blue-600" />
                     ) : (
                       <span className="text-2xl">🎴</span>
                     )}
                     <div>
                       <h3 className="font-semibold text-gray-800">
-                        {isGeneratingQuiz && generatingType === 'flashcard' ? 'Generating...' : 'Flash Cards'}
+                        {isGeneratingQuiz && generatingType === "flashcard"
+                          ? "Generating..."
+                          : "Flash Cards"}
                       </h3>
-                      <p className="text-sm text-gray-600">Create flashcards from selected text</p>
+                      <p className="text-sm text-gray-600">
+                        Create flashcards from selected text
+                      </p>
                     </div>
                   </div>
                 </div>
-                
-                <div 
+
+                <div
                   className={`p-4 rounded-lg border-2 border-green-200 bg-green-50 cursor-pointer hover:shadow-md transition-all ${
-                    isGeneratingQuiz && generatingType === 'multiple-choice' ? 'opacity-50 pointer-events-none' : ''
+                    isGeneratingQuiz && generatingType === "multiple-choice"
+                      ? "opacity-50 pointer-events-none"
+                      : ""
                   }`}
-                  onClick={() => handleQuizToolClick('multiple-choice')}
+                  onClick={() => handleQuizToolClick("multiple-choice")}
                 >
                   <div className="flex items-center space-x-3">
-                    {isGeneratingQuiz && generatingType === 'multiple-choice' ? (
+                    {isGeneratingQuiz &&
+                    generatingType === "multiple-choice" ? (
                       <Loader2 className="w-6 h-6 animate-spin text-green-600" />
                     ) : (
                       <span className="text-2xl">📝</span>
                     )}
                     <div>
                       <h3 className="font-semibold text-gray-800">
-                        {isGeneratingQuiz && generatingType === 'multiple-choice' ? 'Generating...' : 'Multiple Choice'}
+                        {isGeneratingQuiz &&
+                        generatingType === "multiple-choice"
+                          ? "Generating..."
+                          : "Multiple Choice"}
                       </h3>
-                      <p className="text-sm text-gray-600">Generate multiple choice questions</p>
+                      <p className="text-sm text-gray-600">
+                        Generate multiple choice questions
+                      </p>
                     </div>
                   </div>
                 </div>
-                
-                <div 
+
+                <div
                   className={`p-4 rounded-lg border-2 border-purple-200 bg-purple-50 cursor-pointer hover:shadow-md transition-all ${
-                    isGeneratingQuiz && generatingType === 'short-writing' ? 'opacity-50 pointer-events-none' : ''
+                    isGeneratingQuiz && generatingType === "short-writing"
+                      ? "opacity-50 pointer-events-none"
+                      : ""
                   }`}
-                  onClick={() => handleQuizToolClick('short-writing')}
+                  onClick={() => handleQuizToolClick("short-writing")}
                 >
                   <div className="flex items-center space-x-3">
-                    {isGeneratingQuiz && generatingType === 'short-writing' ? (
+                    {isGeneratingQuiz && generatingType === "short-writing" ? (
                       <Loader2 className="w-6 h-6 animate-spin text-purple-600" />
                     ) : (
                       <span className="text-2xl">✍️</span>
                     )}
                     <div>
                       <h3 className="font-semibold text-gray-800">
-                        {isGeneratingQuiz && generatingType === 'short-writing' ? 'Generating...' : 'Short Writing'}
+                        {isGeneratingQuiz && generatingType === "short-writing"
+                          ? "Generating..."
+                          : "Short Writing"}
                       </h3>
-                      <p className="text-sm text-gray-600">Create writing prompts and exercises</p>
+                      <p className="text-sm text-gray-600">
+                        Create writing prompts and exercises
+                      </p>
                     </div>
                   </div>
                 </div>
@@ -749,28 +835,38 @@ export default function MobileEditorLayout() {
               {allQuizzes.length > 0 && (
                 <>
                   <div className="mt-6 pt-4 border-t border-gray-200">
-                    <h3 className="font-semibold text-gray-800 mb-3">All Quizzes ({allQuizzes.length})</h3>
+                    <h3 className="font-semibold text-gray-800 mb-3">
+                      All Quizzes ({allQuizzes.length})
+                    </h3>
                     <div className="space-y-2">
                       {allQuizzes.map((quiz) => {
                         const getQuizIcon = (type: string) => {
                           switch (type) {
-                            case 'flashcard': return '🎴';
-                            case 'multiple-choice': return '📝';
-                            case 'short-writing': return '✍️';
-                            default: return '📄';
+                            case "flashcard":
+                              return "🎴";
+                            case "multiple-choice":
+                              return "📝";
+                            case "short-writing":
+                              return "✍️";
+                            default:
+                              return "📄";
                           }
                         };
 
                         const getItemCount = (quiz: any) => {
                           if (Array.isArray(quiz.data)) {
                             switch (quiz.type) {
-                              case 'flashcard': return `${quiz.data.length} cards`;
-                              case 'multiple-choice': return `${quiz.data.length} questions`;
-                              case 'short-writing': return `${quiz.data.length} tasks`;
-                              default: return `${quiz.data.length} items`;
+                              case "flashcard":
+                                return `${quiz.data.length} cards`;
+                              case "multiple-choice":
+                                return `${quiz.data.length} questions`;
+                              case "short-writing":
+                                return `${quiz.data.length} tasks`;
+                              default:
+                                return `${quiz.data.length} items`;
                             }
                           }
-                          return '0 items';
+                          return "0 items";
                         };
 
                         return (
@@ -779,8 +875,11 @@ export default function MobileEditorLayout() {
                             className="group p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors relative"
                             draggable
                             onDragStart={(e) => {
-                              e.dataTransfer.setData('quiz', JSON.stringify(quiz));
-                              e.dataTransfer.effectAllowed = 'copy';
+                              e.dataTransfer.setData(
+                                "quiz",
+                                JSON.stringify(quiz),
+                              );
+                              e.dataTransfer.effectAllowed = "copy";
                             }}
                             onClick={() => {
                               navigate(`/quiz/${quiz.type}`);
@@ -790,11 +889,19 @@ export default function MobileEditorLayout() {
                             <div className="flex items-start justify-between">
                               <div className="flex-1">
                                 <div className="flex items-center space-x-2">
-                                  <span className="text-sm">{getQuizIcon(quiz.type)}</span>
-                                  <div className="text-sm font-medium text-gray-800 truncate">{quiz.title}</div>
+                                  <span className="text-sm">
+                                    {getQuizIcon(quiz.type)}
+                                  </span>
+                                  <div className="text-sm font-medium text-gray-800 truncate">
+                                    {quiz.title}
+                                  </div>
                                 </div>
-                                <div className="text-xs text-gray-500 mt-1">{getItemCount(quiz)}</div>
-                                <div className="text-xs text-gray-400">{quiz.createdAt.toLocaleDateString()}</div>
+                                <div className="text-xs text-gray-500 mt-1">
+                                  {getItemCount(quiz)}
+                                </div>
+                                <div className="text-xs text-gray-400">
+                                  {quiz.createdAt.toLocaleDateString()}
+                                </div>
                               </div>
                               <div className="opacity-0 group-hover:opacity-100 transition-opacity">
                                 <div className="w-4 h-4 text-gray-400">⋮⋮</div>
@@ -824,7 +931,9 @@ export default function MobileEditorLayout() {
       {showDuplicateWarning && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-red-500 text-white rounded-lg p-4 mx-4 max-w-sm w-full text-center shadow-lg">
-            <h3 className="font-semibold mb-2">There's already a file with the same name</h3>
+            <h3 className="font-semibold mb-2">
+              There's already a file with the same name
+            </h3>
             <Button
               variant="secondary"
               size="sm"
@@ -845,8 +954,12 @@ export default function MobileEditorLayout() {
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
           <div className="bg-white rounded-lg p-6 mx-4 max-w-sm w-full text-center">
             <Loader2 className="w-8 h-8 animate-spin text-blue-600 mx-auto mb-3" />
-            <h3 className="font-semibold text-gray-800 mb-1">Generating Quiz</h3>
-            <p className="text-sm text-gray-600">Please wait while we create your {generatingType} quiz...</p>
+            <h3 className="font-semibold text-gray-800 mb-1">
+              Generating Quiz
+            </h3>
+            <p className="text-sm text-gray-600">
+              Please wait while we create your {generatingType} quiz...
+            </p>
           </div>
         </div>
       )}

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -353,35 +353,9 @@ export default function MobileEditorLayout() {
           <ChevronLeft className="w-5 h-5 text-gray-600" />
         </Button>
         
-        {selectedDocument ? (
-          isEditingTitle ? (
-            <input
-              type="text"
-              value={tempTitle}
-              onChange={(e) => setTempTitle(e.target.value)}
-              onBlur={saveTitleChanges}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  saveTitleChanges();
-                } else if (e.key === 'Escape') {
-                  cancelTitleEditing();
-                }
-              }}
-              className="text-lg font-medium text-gray-900 bg-transparent border-0 focus:outline-none mx-4 flex-1 text-center"
-              placeholder="Document title"
-              autoFocus
-            />
-          ) : (
-            <h1
-              className="text-lg font-medium text-gray-900 truncate mx-4 cursor-pointer hover:bg-gray-100 px-2 py-1 rounded transition-colors"
-              onClick={startEditingTitle}
-            >
-              {getDocumentDisplayName(selectedDocument)}
-            </h1>
-          )
-        ) : (
-          <h1 className="text-lg font-medium text-gray-900 truncate mx-4">Documents</h1>
-        )}
+        <h1 className="text-lg font-medium text-gray-900 truncate mx-4">
+          {selectedDocument ? getDocumentDisplayName(selectedDocument) : 'Documents'}
+        </h1>
         
         <div className="flex items-center space-x-2">
           <Button

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -335,9 +335,35 @@ export default function MobileEditorLayout() {
           <ChevronLeft className="w-5 h-5 text-gray-600" />
         </Button>
         
-        <h1 className="text-lg font-medium text-gray-900 truncate mx-4">
-          {selectedDocument ? getDocumentDisplayName(selectedDocument) : 'Documents'}
-        </h1>
+        {selectedDocument ? (
+          isEditingTitle ? (
+            <input
+              type="text"
+              value={tempTitle}
+              onChange={(e) => setTempTitle(e.target.value)}
+              onBlur={saveTitleChanges}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  saveTitleChanges();
+                } else if (e.key === 'Escape') {
+                  cancelTitleEditing();
+                }
+              }}
+              className="text-lg font-medium text-gray-900 bg-transparent border-0 focus:outline-none mx-4 flex-1 text-center"
+              placeholder="Document title"
+              autoFocus
+            />
+          ) : (
+            <h1
+              className="text-lg font-medium text-gray-900 truncate mx-4 cursor-pointer hover:bg-gray-100 px-2 py-1 rounded transition-colors"
+              onClick={startEditingTitle}
+            >
+              {getDocumentDisplayName(selectedDocument)}
+            </h1>
+          )
+        ) : (
+          <h1 className="text-lg font-medium text-gray-900 truncate mx-4">Documents</h1>
+        )}
         
         <div className="flex items-center space-x-2">
           <Button

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -97,6 +97,7 @@ export default function MobileEditorLayout() {
 
   const selectedDocument = documents.find(doc => doc.id === selectedDocumentId);
   const documentQuizzes = selectedDocument ? getQuizzesByDocument(selectedDocument.id) : [];
+  const allQuizzes = getAllQuizzes();
 
   // Function to extract title from markdown content
   const extractTitleFromContent = (content: string): string => {

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -412,6 +412,34 @@ export default function MobileEditorLayout() {
                 }
               }}
             >
+              {/* Document Title */}
+              {isEditingTitle ? (
+                <input
+                  type="text"
+                  value={tempTitle}
+                  onChange={(e) => setTempTitle(e.target.value)}
+                  onBlur={saveTitleChanges}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      saveTitleChanges();
+                    } else if (e.key === 'Escape') {
+                      cancelTitleEditing();
+                    }
+                  }}
+                  className="text-3xl font-bold text-gray-900 bg-transparent border-0 focus:outline-none mb-8 w-full"
+                  placeholder="Document title"
+                  autoFocus
+                />
+              ) : (
+                <h1
+                  className="text-3xl font-bold text-gray-900 mb-8 cursor-pointer hover:bg-gray-50 px-2 py-1 -mx-2 rounded transition-colors"
+                  onClick={startEditingTitle}
+                >
+                  {selectedDocument.title}
+                </h1>
+              )}
+
+              {/* Document Content */}
               {showPreview ? (
                 <>
                   <div className="mb-4 p-3 bg-orange-50 border border-orange-200 rounded-lg">

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -94,6 +94,8 @@ export default function MobileEditorLayout() {
   });
   const { createQuiz, getQuizzesByDocument, getAllQuizzes } = useQuiz();
   const [isEditingContent, setIsEditingContent] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
+  const [previewContent, setPreviewContent] = useState('');
 
   const selectedDocument = documents.find(doc => doc.id === selectedDocumentId);
   const documentQuizzes = selectedDocument ? getQuizzesByDocument(selectedDocument.id) : [];

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -374,21 +374,12 @@ export default function MobileEditorLayout() {
           variant="ghost"
           size="sm"
           className="flex flex-col items-center space-y-1 p-2"
-          onClick={() => setDocumentsDrawerOpen(true)}
-        >
-          <Layers className="w-5 h-5 text-gray-600" />
-          <span className="text-xs text-gray-600">Docs</span>
-        </Button>
-        
-        <Button
-          variant="ghost"
-          size="sm"
-          className="flex flex-col items-center space-y-1 p-2"
+          onClick={() => setSearchDrawerOpen(true)}
         >
           <Search className="w-5 h-5 text-gray-600" />
           <span className="text-xs text-gray-600">Search</span>
         </Button>
-        
+
         <Button
           variant="ghost"
           size="sm"
@@ -398,7 +389,7 @@ export default function MobileEditorLayout() {
           <Plus className="w-5 h-5 text-gray-600" />
           <span className="text-xs text-gray-600">Add</span>
         </Button>
-        
+
         <Button
           variant="ghost"
           size="sm"
@@ -408,7 +399,7 @@ export default function MobileEditorLayout() {
           <PenTool className="w-5 h-5 text-gray-600" />
           <span className="text-xs text-gray-600">Quiz</span>
         </Button>
-        
+
         <Button
           variant="ghost"
           size="sm"

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -480,6 +480,72 @@ export default function MobileEditorLayout() {
         </>
       )}
 
+      {/* Search Drawer */}
+      {searchDrawerOpen && (
+        <>
+          <div
+            className="fixed inset-0 bg-black bg-opacity-50 z-30"
+            onClick={() => setSearchDrawerOpen(false)}
+          />
+          <div className="fixed bottom-0 left-0 right-0 bg-white rounded-t-xl z-40 max-h-[80vh] overflow-hidden">
+            <div className="flex items-center justify-between p-4 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">Search</h2>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setSearchDrawerOpen(false)}
+              >
+                <X className="w-5 h-5" />
+              </Button>
+            </div>
+
+            <div className="p-4">
+              <input
+                type="text"
+                placeholder="Search documents..."
+                value={searchQuery}
+                onChange={(e) => handleSearch(e.target.value)}
+                className="w-full p-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500"
+                autoFocus
+              />
+            </div>
+
+            <div className="overflow-y-auto max-h-[50vh] px-4 pb-4">
+              {searchResults.length > 0 ? (
+                <div className="space-y-3">
+                  {searchResults.map(({ doc, matches }) => (
+                    <div
+                      key={doc.id}
+                      className="p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors"
+                      onClick={() => handleDocumentSelect(doc.id)}
+                    >
+                      <div className="font-medium text-gray-900 mb-2">{getDocumentDisplayName(doc)}</div>
+                      {matches.map((match, index) => (
+                        <div
+                          key={index}
+                          className="text-sm text-gray-600 mb-1 leading-relaxed"
+                          dangerouslySetInnerHTML={{
+                            __html: highlightSearchTerm(match.substring(0, 100) + (match.length > 100 ? '...' : ''), searchQuery)
+                          }}
+                        />
+                      ))}
+                    </div>
+                  ))}
+                </div>
+              ) : searchQuery ? (
+                <div className="text-center py-8 text-gray-500">
+                  No results found for "{searchQuery}"
+                </div>
+              ) : (
+                <div className="text-center py-8 text-gray-500">
+                  Type to search through all documents
+                </div>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
       {/* Quiz Tools Drawer */}
       {quizDrawerOpen && (
         <>

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -1,0 +1,615 @@
+import React, { useState, useEffect, useRef } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { 
+  ChevronLeft, 
+  FileText, 
+  Plus, 
+  Menu, 
+  X, 
+  Settings, 
+  Loader2, 
+  Search,
+  Bookmark,
+  MoreVertical,
+  Home,
+  Layers,
+  PenTool,
+  Grid
+} from 'lucide-react';
+import { Button } from './ui/button';
+import SettingsModal, { AppSettings } from './SettingsModal';
+import { getLLMService } from '../services/llmService';
+import { useQuiz } from '../contexts/QuizContext';
+
+interface Document {
+  id: string;
+  name: string;
+  content: string;
+  createdAt: Date;
+}
+
+const initialDocuments: Document[] = [
+  {
+    id: '1',
+    name: 'English 2',
+    content: 'Welcome to English 2! Start writing your notes here...',
+    createdAt: new Date('2024-01-15')
+  },
+  {
+    id: '2',
+    name: 'English 3',
+    content: 'Welcome to English 3! This is your study space.',
+    createdAt: new Date('2024-01-16')
+  },
+  {
+    id: '3',
+    name: 'English 4',
+    content: `# English 4
+
+Companies often **hedge** against currency fluctuations to protect their profits [hedge is an investment that is made to reduce the risk of adverse price movements in an asset]
+
+Investors often **hedge** their bets by buying different types of assets [To reduce or protect against the risk of loss, especially in finance.]
+
+A **hedge** fund is a private, unregistered investment fund. Hedge funds pool money from investors and invest in securities or other types of assets with the goal of getting positive returns.
+
+He **hedged** when asked about his future plans. [avoid giving a direct answer]
+
+Her **dogged** efforts to learn the piano finally paid off when she performed at the concert. [is persistent, determined, and doesn't give up easily, even when facing difficulties]
+
+He was caught **doctoring** the financial records to hide his mistakes [To alter or falsify something (often secretly or dishonestly) to deceive others]
+
+She **doctored** the old chair to make it usable again. [repair]
+
+It's illegal to **falsify** your resume by lying about your qualifications [alter or create something false in order to deceive others, often to hide the truth or gain an unfair advantage]
+
+A company conducting **due diligence** before acquiring another business to check its finances and legal liabilities. [careful, thorough, and systematic effort or research done to gather information, assess risks, or verify facts before making a decision]
+
+The company took on significant **liability** after the accident, as they had to pay for damages. [Legal or financial responsibility for something, especially for`,
+    createdAt: new Date('2024-01-17')
+  }
+];
+
+export default function MobileEditorLayout() {
+  const navigate = useNavigate();
+  const [documents, setDocuments] = useState<Document[]>(initialDocuments);
+  const [selectedDocumentId, setSelectedDocumentId] = useState<string>('3');
+  const [selectedText, setSelectedText] = useState('');
+  const [documentsDrawerOpen, setDocumentsDrawerOpen] = useState(false);
+  const [quizDrawerOpen, setQuizDrawerOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [isGeneratingQuiz, setIsGeneratingQuiz] = useState(false);
+  const [generatingType, setGeneratingType] = useState<string>('');
+  const [settings, setSettings] = useState<AppSettings>({
+    general: {
+      languageLevel: 'cet4'
+    },
+    llm: {
+      apiKey: 'AIzaSyCNDJgpRcdDiEVSNomjIMTW1yNWjX7K6P0',
+      provider: 'gemini',
+      model: 'gemini-2.0-flash-exp'
+    }
+  });
+  const { createQuiz, getQuizzesByDocument } = useQuiz();
+  const [isEditingContent, setIsEditingContent] = useState(false);
+
+  const selectedDocument = documents.find(doc => doc.id === selectedDocumentId);
+  const documentQuizzes = selectedDocument ? getQuizzesByDocument(selectedDocument.id) : [];
+
+  // Function to extract title from markdown content
+  const extractTitleFromContent = (content: string): string => {
+    const lines = content.split('\n');
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.startsWith('# ')) {
+        return trimmed.substring(2).trim();
+      }
+    }
+    return '';
+  };
+
+  // Function to get display name for document
+  const getDocumentDisplayName = (doc: Document): string => {
+    const titleFromContent = extractTitleFromContent(doc.content);
+    return titleFromContent || doc.name;
+  };
+
+  // Update document name when content changes
+  useEffect(() => {
+    if (selectedDocument) {
+      const titleFromContent = extractTitleFromContent(selectedDocument.content);
+      if (titleFromContent && titleFromContent !== selectedDocument.name) {
+        setDocuments(prev =>
+          prev.map(doc =>
+            doc.id === selectedDocument.id
+              ? { ...doc, name: titleFromContent }
+              : doc
+          )
+        );
+      }
+    }
+  }, [selectedDocument?.content]);
+
+  const handleQuizToolClick = async (toolId: string) => {
+    if (!selectedText) {
+      alert('Please select some text first to generate a quiz!');
+      return;
+    }
+
+    if (!settings.llm.apiKey) {
+      alert('Please configure your LLM API key in settings first!');
+      setSettingsOpen(true);
+      return;
+    }
+
+    setIsGeneratingQuiz(true);
+    setGeneratingType(toolId);
+    setQuizDrawerOpen(false);
+
+    try {
+      const llmService = getLLMService(settings);
+
+      switch (toolId) {
+        case 'flashcard': {
+          const flashcards = await llmService.generateFlashCards(selectedText);
+          createQuiz('flashcard', `Flashcards - ${getDocumentDisplayName(selectedDocument!)}`, selectedText, flashcards, selectedDocument!.id);
+          navigate('/quiz/flashcard');
+          break;
+        }
+        case 'multiple-choice': {
+          const questions = await llmService.generateMultipleChoice(selectedText);
+          createQuiz('multiple-choice', `Multiple Choice - ${getDocumentDisplayName(selectedDocument!)}`, selectedText, questions, selectedDocument!.id);
+          navigate('/quiz/multiple-choice');
+          break;
+        }
+        case 'short-writing': {
+          const tasks = await llmService.generateWritingTasks(selectedText);
+          createQuiz('short-writing', `Writing Tasks - ${getDocumentDisplayName(selectedDocument!)}`, selectedText, tasks, selectedDocument!.id);
+          navigate('/quiz/short-writing');
+          break;
+        }
+      }
+    } catch (error) {
+      console.error('Error generating quiz:', error);
+      alert(`Failed to generate quiz: ${error instanceof Error ? error.message : 'Unknown error'}`);
+    } finally {
+      setIsGeneratingQuiz(false);
+      setGeneratingType('');
+    }
+  };
+
+  const handleTextSelection = () => {
+    const selection = window.getSelection();
+    if (selection && selection.toString()) {
+      setSelectedText(selection.toString());
+    }
+  };
+
+  const handleAddDocument = () => {
+    const newId = (Math.max(...documents.map(d => parseInt(d.id))) + 1).toString();
+    const newDocument: Document = {
+      id: newId,
+      name: 'New Document',
+      content: '# New Document\n\nStart writing your content here...',
+      createdAt: new Date()
+    };
+
+    setDocuments(prev => [...prev, newDocument]);
+    setSelectedDocumentId(newId);
+    setDocumentsDrawerOpen(false);
+  };
+
+  const handleDeleteDocument = (docId: string) => {
+    if (documents.length <= 1) {
+      alert('You must have at least one document.');
+      return;
+    }
+    
+    if (confirm('Are you sure you want to delete this document?')) {
+      setDocuments(prev => prev.filter(doc => doc.id !== docId));
+      
+      if (selectedDocumentId === docId) {
+        const remainingDocs = documents.filter(doc => doc.id !== docId);
+        setSelectedDocumentId(remainingDocs[0]?.id || '');
+      }
+    }
+  };
+
+  const handleDocumentSelect = (docId: string) => {
+    setSelectedDocumentId(docId);
+    setSelectedText('');
+    setDocumentsDrawerOpen(false);
+  };
+
+  const handleContentChange = (newContent: string) => {
+    if (selectedDocument) {
+      setDocuments(prev => 
+        prev.map(doc => 
+          doc.id === selectedDocument.id 
+            ? { ...doc, content: newContent }
+            : doc
+        )
+      );
+    }
+  };
+
+  const renderMobileMarkdownContent = (content: string) => {
+    return content
+      .split('\n')
+      .map((line, index) => {
+        if (line.startsWith('# ')) {
+          return <h1 key={index} className="text-2xl font-bold mb-6 mt-8 text-gray-900">{line.substring(2)}</h1>;
+        }
+        if (line.startsWith('## ')) {
+          return <h2 key={index} className="text-xl font-semibold mb-4 mt-6 text-gray-900">{line.substring(3)}</h2>;
+        }
+        if (line.trim() === '') {
+          return <div key={index} className="mb-4"></div>;
+        }
+
+        // Handle mobile-optimized markdown formatting
+        const processedLine = line
+          .replace(/\*\*(.*?)\*\*/g, '<span class="bg-yellow-200 px-1 py-0.5 rounded font-medium text-gray-900">$1</span>')
+          .replace(/\[([^\]]+)\]/g, '<span class="text-purple-600 text-sm block mt-1 leading-relaxed">[$1]</span>');
+
+        return (
+          <p
+            key={index}
+            className="mb-4 leading-relaxed text-gray-800 text-base"
+            dangerouslySetInnerHTML={{ __html: processedLine }}
+          />
+        );
+      });
+  };
+
+  return (
+    <div className="h-screen flex flex-col bg-white relative overflow-hidden">
+      {/* Top Navigation Bar */}
+      <div className="flex items-center justify-between px-4 py-3 bg-white border-b border-gray-200 relative z-20">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="p-2"
+          onClick={() => setDocumentsDrawerOpen(true)}
+        >
+          <ChevronLeft className="w-5 h-5 text-gray-600" />
+        </Button>
+        
+        <h1 className="text-lg font-medium text-gray-900 truncate mx-4">
+          {selectedDocument ? getDocumentDisplayName(selectedDocument) : 'Documents'}
+        </h1>
+        
+        <div className="flex items-center space-x-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="p-2"
+          >
+            <Bookmark className="w-5 h-5 text-gray-600" />
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="p-2"
+            onClick={() => setSettingsOpen(true)}
+          >
+            <MoreVertical className="w-5 h-5 text-gray-600" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Main Content Area */}
+      <div className="flex-1 overflow-y-auto px-4 py-6 bg-white">
+        {selectedDocument ? (
+          isEditingContent ? (
+            <textarea
+              value={selectedDocument.content}
+              onChange={(e) => handleContentChange(e.target.value)}
+              onBlur={() => setIsEditingContent(false)}
+              className="w-full min-h-[calc(100vh-200px)] p-0 border-0 resize-none focus:outline-none bg-transparent text-base leading-relaxed"
+              placeholder="Start writing your document content here..."
+              autoFocus
+            />
+          ) : (
+            <div
+              className="min-h-[calc(100vh-200px)] cursor-text"
+              onMouseUp={handleTextSelection}
+              onTouchEnd={handleTextSelection}
+              onDoubleClick={() => setIsEditingContent(true)}
+            >
+              {renderMobileMarkdownContent(selectedDocument.content)}
+            </div>
+          )
+        ) : (
+          <div className="flex items-center justify-center h-full">
+            <div className="text-center">
+              <FileText className="w-16 h-16 text-gray-300 mx-auto mb-4" />
+              <p className="text-gray-500 mb-4">Select a document to start</p>
+              <Button onClick={() => setDocumentsDrawerOpen(true)}>
+                View Documents
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Bottom Navigation */}
+      <div className="flex items-center justify-around px-4 py-3 bg-white border-t border-gray-200 relative z-20">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex flex-col items-center space-y-1 p-2"
+          onClick={() => setDocumentsDrawerOpen(true)}
+        >
+          <Layers className="w-5 h-5 text-gray-600" />
+          <span className="text-xs text-gray-600">Docs</span>
+        </Button>
+        
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex flex-col items-center space-y-1 p-2"
+        >
+          <Search className="w-5 h-5 text-gray-600" />
+          <span className="text-xs text-gray-600">Search</span>
+        </Button>
+        
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex flex-col items-center space-y-1 p-2"
+          onClick={handleAddDocument}
+        >
+          <Plus className="w-5 h-5 text-gray-600" />
+          <span className="text-xs text-gray-600">Add</span>
+        </Button>
+        
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex flex-col items-center space-y-1 p-2"
+          onClick={() => setQuizDrawerOpen(true)}
+        >
+          <PenTool className="w-5 h-5 text-gray-600" />
+          <span className="text-xs text-gray-600">Quiz</span>
+        </Button>
+        
+        <Button
+          variant="ghost"
+          size="sm"
+          className="flex flex-col items-center space-y-1 p-2"
+        >
+          <Grid className="w-5 h-5 text-gray-600" />
+          <span className="text-xs text-gray-600">More</span>
+        </Button>
+      </div>
+
+      {/* Documents Drawer */}
+      {documentsDrawerOpen && (
+        <>
+          <div 
+            className="fixed inset-0 bg-black bg-opacity-50 z-30"
+            onClick={() => setDocumentsDrawerOpen(false)}
+          />
+          <div className="fixed bottom-0 left-0 right-0 bg-white rounded-t-xl z-40 max-h-[80vh] overflow-hidden">
+            <div className="flex items-center justify-between p-4 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">Documents</h2>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setDocumentsDrawerOpen(false)}
+              >
+                <X className="w-5 h-5" />
+              </Button>
+            </div>
+            
+            <div className="overflow-y-auto max-h-[60vh] p-4">
+              <div className="space-y-2">
+                {documents.map((doc) => (
+                  <div
+                    key={doc.id}
+                    className={`flex items-center justify-between p-4 rounded-lg cursor-pointer transition-colors ${
+                      selectedDocumentId === doc.id 
+                        ? 'bg-blue-50 border border-blue-200' 
+                        : 'bg-gray-50 hover:bg-gray-100'
+                    }`}
+                    onClick={() => handleDocumentSelect(doc.id)}
+                  >
+                    <div className="flex items-center flex-1 min-w-0">
+                      <FileText className={`w-5 h-5 mr-3 flex-shrink-0 ${
+                        selectedDocumentId === doc.id ? 'text-blue-500' : 'text-gray-500'
+                      }`} />
+                      <div className="min-w-0 flex-1">
+                        <div className="font-medium text-gray-900 truncate">{getDocumentDisplayName(doc)}</div>
+                        <div className="text-sm text-gray-500">{doc.createdAt.toLocaleDateString()}</div>
+                      </div>
+                    </div>
+                    {documents.length > 1 && (
+                      <Button
+                        variant="ghost"
+                        size="sm"
+                        className="ml-2 p-2"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeleteDocument(doc.id);
+                        }}
+                      >
+                        <X className="w-4 h-4 text-red-500" />
+                      </Button>
+                    )}
+                  </div>
+                ))}
+              </div>
+              
+              <Button
+                variant="outline"
+                className="w-full mt-4"
+                onClick={handleAddDocument}
+              >
+                <Plus className="w-4 h-4 mr-2" />
+                Add New Document
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Quiz Tools Drawer */}
+      {quizDrawerOpen && (
+        <>
+          <div 
+            className="fixed inset-0 bg-black bg-opacity-50 z-30"
+            onClick={() => setQuizDrawerOpen(false)}
+          />
+          <div className="fixed bottom-0 left-0 right-0 bg-white rounded-t-xl z-40 max-h-[80vh] overflow-hidden">
+            <div className="flex items-center justify-between p-4 border-b border-gray-200">
+              <h2 className="text-lg font-semibold text-gray-900">Quiz Tools</h2>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setQuizDrawerOpen(false)}
+              >
+                <X className="w-5 h-5" />
+              </Button>
+            </div>
+            
+            <div className="overflow-y-auto max-h-[60vh] p-4">
+              {selectedText ? (
+                <div className="p-3 bg-blue-50 border border-blue-200 rounded-lg mb-4">
+                  <div className="font-medium text-blue-800 mb-1">Selected text:</div>
+                  <div className="text-blue-700 text-sm">"{selectedText.substring(0, 100)}{selectedText.length > 100 ? '...' : '"'}</div>
+                </div>
+              ) : (
+                <div className="p-3 bg-gray-50 border border-gray-200 rounded-lg mb-4">
+                  <div className="text-gray-600 text-sm">Select text in the document to generate quizzes</div>
+                </div>
+              )}
+
+              <div className="space-y-3">
+                <div 
+                  className={`p-4 rounded-lg border-2 border-blue-200 bg-blue-50 cursor-pointer hover:shadow-md transition-all ${
+                    isGeneratingQuiz && generatingType === 'flashcard' ? 'opacity-50 pointer-events-none' : ''
+                  }`}
+                  onClick={() => handleQuizToolClick('flashcard')}
+                >
+                  <div className="flex items-center space-x-3">
+                    {isGeneratingQuiz && generatingType === 'flashcard' ? (
+                      <Loader2 className="w-6 h-6 animate-spin text-blue-600" />
+                    ) : (
+                      <span className="text-2xl">🎴</span>
+                    )}
+                    <div>
+                      <h3 className="font-semibold text-gray-800">
+                        {isGeneratingQuiz && generatingType === 'flashcard' ? 'Generating...' : 'Flash Cards'}
+                      </h3>
+                      <p className="text-sm text-gray-600">Create flashcards from selected text</p>
+                    </div>
+                  </div>
+                </div>
+                
+                <div 
+                  className={`p-4 rounded-lg border-2 border-green-200 bg-green-50 cursor-pointer hover:shadow-md transition-all ${
+                    isGeneratingQuiz && generatingType === 'multiple-choice' ? 'opacity-50 pointer-events-none' : ''
+                  }`}
+                  onClick={() => handleQuizToolClick('multiple-choice')}
+                >
+                  <div className="flex items-center space-x-3">
+                    {isGeneratingQuiz && generatingType === 'multiple-choice' ? (
+                      <Loader2 className="w-6 h-6 animate-spin text-green-600" />
+                    ) : (
+                      <span className="text-2xl">📝</span>
+                    )}
+                    <div>
+                      <h3 className="font-semibold text-gray-800">
+                        {isGeneratingQuiz && generatingType === 'multiple-choice' ? 'Generating...' : 'Multiple Choice'}
+                      </h3>
+                      <p className="text-sm text-gray-600">Generate multiple choice questions</p>
+                    </div>
+                  </div>
+                </div>
+                
+                <div 
+                  className={`p-4 rounded-lg border-2 border-purple-200 bg-purple-50 cursor-pointer hover:shadow-md transition-all ${
+                    isGeneratingQuiz && generatingType === 'short-writing' ? 'opacity-50 pointer-events-none' : ''
+                  }`}
+                  onClick={() => handleQuizToolClick('short-writing')}
+                >
+                  <div className="flex items-center space-x-3">
+                    {isGeneratingQuiz && generatingType === 'short-writing' ? (
+                      <Loader2 className="w-6 h-6 animate-spin text-purple-600" />
+                    ) : (
+                      <span className="text-2xl">✍️</span>
+                    )}
+                    <div>
+                      <h3 className="font-semibold text-gray-800">
+                        {isGeneratingQuiz && generatingType === 'short-writing' ? 'Generating...' : 'Short Writing'}
+                      </h3>
+                      <p className="text-sm text-gray-600">Create writing prompts and exercises</p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              {documentQuizzes.length > 0 && (
+                <>
+                  <div className="mt-6 pt-4 border-t border-gray-200">
+                    <h3 className="font-semibold text-gray-800 mb-3">Recent Quizzes</h3>
+                    <div className="space-y-2">
+                      {documentQuizzes.slice(0, 3).map((quiz) => {
+                        const getQuizIcon = (type: string) => {
+                          switch (type) {
+                            case 'flashcard': return '🎴';
+                            case 'multiple-choice': return '📝';
+                            case 'short-writing': return '✍️';
+                            default: return '📄';
+                          }
+                        };
+
+                        return (
+                          <div
+                            key={quiz.id}
+                            className="p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors"
+                            onClick={() => {
+                              navigate(`/quiz/${quiz.type}`);
+                              setQuizDrawerOpen(false);
+                            }}
+                          >
+                            <div className="flex items-center space-x-3">
+                              <span className="text-lg">{getQuizIcon(quiz.type)}</span>
+                              <div>
+                                <div className="font-medium text-gray-800 text-sm truncate">{quiz.title}</div>
+                                <div className="text-xs text-gray-500">{quiz.createdAt.toLocaleDateString()}</div>
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                </>
+              )}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Settings Modal */}
+      <SettingsModal
+        isOpen={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        settings={settings}
+        onSettingsChange={setSettings}
+      />
+
+      {/* Loading Overlay */}
+      {isGeneratingQuiz && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-white rounded-lg p-6 mx-4 max-w-sm w-full text-center">
+            <Loader2 className="w-8 h-8 animate-spin text-blue-600 mx-auto mb-3" />
+            <h3 className="font-semibold text-gray-800 mb-1">Generating Quiz</h3>
+            <p className="text-sm text-gray-600">Please wait while we create your {generatingType} quiz...</p>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -642,12 +642,12 @@ export default function MobileEditorLayout() {
                 </div>
               </div>
 
-              {documentQuizzes.length > 0 && (
+              {allQuizzes.length > 0 && (
                 <>
                   <div className="mt-6 pt-4 border-t border-gray-200">
-                    <h3 className="font-semibold text-gray-800 mb-3">Recent Quizzes</h3>
+                    <h3 className="font-semibold text-gray-800 mb-3">All Quizzes ({allQuizzes.length})</h3>
                     <div className="space-y-2">
-                      {documentQuizzes.slice(0, 3).map((quiz) => {
+                      {allQuizzes.map((quiz) => {
                         const getQuizIcon = (type: string) => {
                           switch (type) {
                             case 'flashcard': return '🎴';
@@ -657,20 +657,43 @@ export default function MobileEditorLayout() {
                           }
                         };
 
+                        const getItemCount = (quiz: any) => {
+                          if (Array.isArray(quiz.data)) {
+                            switch (quiz.type) {
+                              case 'flashcard': return `${quiz.data.length} cards`;
+                              case 'multiple-choice': return `${quiz.data.length} questions`;
+                              case 'short-writing': return `${quiz.data.length} tasks`;
+                              default: return `${quiz.data.length} items`;
+                            }
+                          }
+                          return '0 items';
+                        };
+
                         return (
                           <div
                             key={quiz.id}
-                            className="p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors"
+                            className="group p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors relative"
+                            draggable
+                            onDragStart={(e) => {
+                              e.dataTransfer.setData('quiz', JSON.stringify(quiz));
+                              e.dataTransfer.effectAllowed = 'copy';
+                            }}
                             onClick={() => {
                               navigate(`/quiz/${quiz.type}`);
                               setQuizDrawerOpen(false);
                             }}
                           >
-                            <div className="flex items-center space-x-3">
-                              <span className="text-lg">{getQuizIcon(quiz.type)}</span>
-                              <div>
-                                <div className="font-medium text-gray-800 text-sm truncate">{quiz.title}</div>
-                                <div className="text-xs text-gray-500">{quiz.createdAt.toLocaleDateString()}</div>
+                            <div className="flex items-start justify-between">
+                              <div className="flex-1">
+                                <div className="flex items-center space-x-2">
+                                  <span className="text-sm">{getQuizIcon(quiz.type)}</span>
+                                  <div className="text-sm font-medium text-gray-800 truncate">{quiz.title}</div>
+                                </div>
+                                <div className="text-xs text-gray-500 mt-1">{getItemCount(quiz)}</div>
+                                <div className="text-xs text-gray-400">{quiz.createdAt.toLocaleDateString()}</div>
+                              </div>
+                              <div className="opacity-0 group-hover:opacity-100 transition-opacity">
+                                <div className="w-4 h-4 text-gray-400">⋮⋮</div>
                               </div>
                             </div>
                           </div>

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -92,7 +92,7 @@ export default function MobileEditorLayout() {
       model: 'gemini-2.0-flash-exp'
     }
   });
-  const { createQuiz, getQuizzesByDocument } = useQuiz();
+  const { createQuiz, getQuizzesByDocument, getAllQuizzes } = useQuiz();
   const [isEditingContent, setIsEditingContent] = useState(false);
 
   const selectedDocument = documents.find(doc => doc.id === selectedDocumentId);

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -371,7 +371,26 @@ export default function MobileEditorLayout() {
                 }
               }}
             >
-              {renderMobileMarkdownContent(selectedDocument.content)}
+              {showPreview ? (
+                <>
+                  <div className="mb-4 p-3 bg-orange-50 border border-orange-200 rounded-lg">
+                    <div className="font-medium text-orange-800 mb-2">📖 Quiz Source Preview</div>
+                    <Button
+                      size="sm"
+                      variant="outline"
+                      onClick={() => {
+                        setShowPreview(false);
+                        setPreviewContent('');
+                      }}
+                    >
+                      Return to Document
+                    </Button>
+                  </div>
+                  {renderMobileMarkdownContent(previewContent)}
+                </>
+              ) : (
+                renderMobileMarkdownContent(selectedDocument.content)
+              )}
             </div>
           )
         ) : (

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -429,7 +429,7 @@ export default function MobileEditorLayout() {
               </Button>
             </div>
             
-            <div className="overflow-y-auto max-h-[60vh] p-4">
+            <div className="overflow-y-auto flex-1 p-4">
               <div className="space-y-2">
                 {documents.map((doc) => (
                   <div

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -353,6 +353,23 @@ export default function MobileEditorLayout() {
               onMouseUp={handleTextSelection}
               onTouchEnd={handleTextSelection}
               onDoubleClick={() => setIsEditingContent(true)}
+              onDragOver={(e) => {
+                e.preventDefault();
+                e.dataTransfer.dropEffect = 'copy';
+              }}
+              onDrop={(e) => {
+                e.preventDefault();
+                const quizData = e.dataTransfer.getData('quiz');
+                if (quizData) {
+                  try {
+                    const quiz = JSON.parse(quizData);
+                    setPreviewContent(quiz.sourceText);
+                    setShowPreview(true);
+                  } catch (error) {
+                    console.error('Error parsing dropped quiz data:', error);
+                  }
+                }
+              }}
             >
               {renderMobileMarkdownContent(selectedDocument.content)}
             </div>

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -238,11 +238,6 @@ export default function MobileEditorLayout() {
     setDocuments(prev => [...prev, newDocument]);
     setSelectedDocumentId(newId);
     setDocumentsDrawerOpen(false);
-
-    // Start editing the title immediately for new documents
-    setTimeout(() => {
-      startEditingTitle();
-    }, 100);
   };
 
   const handleDeleteDocument = (docId: string) => {

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -803,6 +803,26 @@ export default function MobileEditorLayout() {
         onSettingsChange={setSettings}
       />
 
+      {/* Duplicate Title Warning */}
+      {showDuplicateWarning && (
+        <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+          <div className="bg-red-500 text-white rounded-lg p-4 mx-4 max-w-sm w-full text-center shadow-lg">
+            <h3 className="font-semibold mb-2">There's already a file with the same name</h3>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => {
+                setShowDuplicateWarning(false);
+                setIsEditingTitle(true);
+              }}
+              className="bg-white text-red-500 hover:bg-gray-100"
+            >
+              Try Again
+            </Button>
+          </div>
+        </div>
+      )}
+
       {/* Loading Overlay */}
       {isGeneratingQuiz && (
         <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -410,14 +410,14 @@ export default function MobileEditorLayout() {
         </Button>
       </div>
 
-      {/* Documents Drawer */}
+      {/* Documents Drawer - Slide from Left */}
       {documentsDrawerOpen && (
         <>
-          <div 
+          <div
             className="fixed inset-0 bg-black bg-opacity-50 z-30"
             onClick={() => setDocumentsDrawerOpen(false)}
           />
-          <div className="fixed bottom-0 left-0 right-0 bg-white rounded-t-xl z-40 max-h-[80vh] overflow-hidden">
+          <div className="fixed top-0 left-0 bottom-0 bg-white z-40 w-80 max-w-[85vw] overflow-hidden shadow-xl">
             <div className="flex items-center justify-between p-4 border-b border-gray-200">
               <h2 className="text-lg font-semibold text-gray-900">Documents</h2>
               <Button

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -222,6 +222,38 @@ export default function MobileEditorLayout() {
     setSelectedDocumentId(docId);
     setSelectedText('');
     setDocumentsDrawerOpen(false);
+    setSearchDrawerOpen(false);
+  };
+
+  const handleSearch = (query: string) => {
+    setSearchQuery(query);
+    if (!query.trim()) {
+      setSearchResults([]);
+      return;
+    }
+
+    const results: {doc: Document, matches: string[]}[] = [];
+    documents.forEach(doc => {
+      const content = doc.content.toLowerCase();
+      const searchTerm = query.toLowerCase();
+
+      if (content.includes(searchTerm) || getDocumentDisplayName(doc).toLowerCase().includes(searchTerm)) {
+        const lines = doc.content.split('\n');
+        const matches = lines
+          .filter(line => line.toLowerCase().includes(searchTerm))
+          .slice(0, 3); // Limit to 3 matches per document
+
+        results.push({ doc, matches });
+      }
+    });
+
+    setSearchResults(results);
+  };
+
+  const highlightSearchTerm = (text: string, query: string) => {
+    if (!query) return text;
+    const regex = new RegExp(`(${query})`, 'gi');
+    return text.replace(regex, '<mark class="bg-yellow-300">$1</mark>');
   };
 
   const handleContentChange = (newContent: string) => {

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -102,39 +102,61 @@ export default function MobileEditorLayout() {
   const documentQuizzes = selectedDocument ? getQuizzesByDocument(selectedDocument.id) : [];
   const allQuizzes = getAllQuizzes();
 
-  // Function to extract title from markdown content
-  const extractTitleFromContent = (content: string): string => {
-    const lines = content.split('\n');
-    for (const line of lines) {
-      const trimmed = line.trim();
-      if (trimmed.startsWith('# ')) {
-        return trimmed.substring(2).trim();
-      }
-    }
-    return '';
-  };
-
   // Function to get display name for document
   const getDocumentDisplayName = (doc: Document): string => {
-    const titleFromContent = extractTitleFromContent(doc.content);
-    return titleFromContent || doc.name;
+    return doc.title;
   };
 
-  // Update document name when content changes
-  useEffect(() => {
+  // Check if title already exists in other documents
+  const isTitleDuplicate = (title: string, excludeId?: string): boolean => {
+    return documents.some(doc =>
+      doc.title.toLowerCase() === title.toLowerCase() &&
+      doc.id !== excludeId
+    );
+  };
+
+  // Start editing title
+  const startEditingTitle = () => {
     if (selectedDocument) {
-      const titleFromContent = extractTitleFromContent(selectedDocument.content);
-      if (titleFromContent && titleFromContent !== selectedDocument.name) {
-        setDocuments(prev =>
-          prev.map(doc =>
-            doc.id === selectedDocument.id
-              ? { ...doc, name: titleFromContent }
-              : doc
-          )
-        );
-      }
+      setTempTitle(selectedDocument.title);
+      setIsEditingTitle(true);
     }
-  }, [selectedDocument?.content]);
+  };
+
+  // Save title changes
+  const saveTitleChanges = () => {
+    if (!selectedDocument || !tempTitle.trim()) {
+      setIsEditingTitle(false);
+      return;
+    }
+
+    const trimmedTitle = tempTitle.trim();
+
+    // Check for duplicates
+    if (isTitleDuplicate(trimmedTitle, selectedDocument.id)) {
+      setShowDuplicateWarning(true);
+      return;
+    }
+
+    // Update document title
+    setDocuments(prev =>
+      prev.map(doc =>
+        doc.id === selectedDocument.id
+          ? { ...doc, title: trimmedTitle }
+          : doc
+      )
+    );
+
+    setIsEditingTitle(false);
+    setTempTitle('');
+  };
+
+  // Cancel title editing
+  const cancelTitleEditing = () => {
+    setIsEditingTitle(false);
+    setTempTitle('');
+    setShowDuplicateWarning(false);
+  };
 
   const handleQuizToolClick = async (toolId: string) => {
     if (!selectedText) {

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -315,8 +315,9 @@ export default function MobileEditorLayout() {
     return content
       .split('\n')
       .map((line, index) => {
+        // Skip H1 headers as title is now handled separately
         if (line.startsWith('# ')) {
-          return <h1 key={index} className="text-2xl font-bold mb-6 mt-8 text-gray-900">{line.substring(2)}</h1>;
+          return null;
         }
         if (line.startsWith('## ')) {
           return <h2 key={index} className="text-xl font-semibold mb-4 mt-6 text-gray-900">{line.substring(3)}</h2>;
@@ -337,7 +338,8 @@ export default function MobileEditorLayout() {
             dangerouslySetInnerHTML={{ __html: processedLine }}
           />
         );
-      });
+      })
+      .filter(Boolean); // Remove null values from skipped H1 headers
   };
 
   return (

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -215,16 +215,34 @@ export default function MobileEditorLayout() {
 
   const handleAddDocument = () => {
     const newId = (Math.max(...documents.map(d => parseInt(d.id))) + 1).toString();
+
+    // Generate unique title
+    let baseTitle = 'New Document';
+    let titleSuffix = '';
+    let counter = 1;
+
+    while (isTitleDuplicate(baseTitle + titleSuffix)) {
+      titleSuffix = ` ${counter}`;
+      counter++;
+    }
+
+    const uniqueTitle = baseTitle + titleSuffix;
+
     const newDocument: Document = {
       id: newId,
-      name: 'New Document',
-      content: '# New Document\n\nStart writing your content here...',
+      title: uniqueTitle,
+      content: 'Start writing your content here...',
       createdAt: new Date()
     };
 
     setDocuments(prev => [...prev, newDocument]);
     setSelectedDocumentId(newId);
     setDocumentsDrawerOpen(false);
+
+    // Start editing the title immediately for new documents
+    setTimeout(() => {
+      startEditingTitle();
+    }, 100);
   };
 
   const handleDeleteDocument = (docId: string) => {

--- a/client/components/MobileEditorLayout.tsx
+++ b/client/components/MobileEditorLayout.tsx
@@ -76,6 +76,9 @@ export default function MobileEditorLayout() {
   const [selectedText, setSelectedText] = useState('');
   const [documentsDrawerOpen, setDocumentsDrawerOpen] = useState(false);
   const [quizDrawerOpen, setQuizDrawerOpen] = useState(false);
+  const [searchDrawerOpen, setSearchDrawerOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<{doc: Document, matches: string[]}[]>([]);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [isGeneratingQuiz, setIsGeneratingQuiz] = useState(false);
   const [generatingType, setGeneratingType] = useState<string>('');

--- a/client/contexts/QuizContext.tsx
+++ b/client/contexts/QuizContext.tsx
@@ -42,6 +42,7 @@ interface QuizContextType {
   getQuizzesByDocument: (documentId: string) => Quiz[];
   getQuizzesByDocumentAndType: (documentId: string, type: Quiz['type']) => Quiz[];
   getLatestQuizByType: (type: Quiz['type']) => Quiz | null;
+  getAllQuizzes: () => Quiz[];
   deleteQuiz: (id: string) => void;
   setCurrentQuiz: (quiz: Quiz | null) => void;
 }

--- a/client/contexts/QuizContext.tsx
+++ b/client/contexts/QuizContext.tsx
@@ -175,6 +175,10 @@ export function QuizProvider({ children }: { children: ReactNode }) {
     return typeQuizzes.length > 0 ? typeQuizzes[typeQuizzes.length - 1] : null;
   };
 
+  const getAllQuizzes = () => {
+    return quizzes.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  };
+
   const deleteQuiz = (id: string) => {
     setQuizzes(prev => prev.filter(quiz => quiz.id !== id));
   };

--- a/client/contexts/QuizContext.tsx
+++ b/client/contexts/QuizContext.tsx
@@ -194,6 +194,7 @@ export function QuizProvider({ children }: { children: ReactNode }) {
       getQuizzesByDocument,
       getQuizzesByDocumentAndType,
       getLatestQuizByType,
+      getAllQuizzes,
       deleteQuiz,
       setCurrentQuiz
     }}>

--- a/client/contexts/QuizContext.tsx
+++ b/client/contexts/QuizContext.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useState, ReactNode } from 'react';
+import React, { createContext, useContext, useState, ReactNode } from "react";
 
 interface FlashCard {
   id: string;
@@ -24,7 +24,7 @@ interface WritingTask {
 
 interface Quiz {
   id: string;
-  type: 'flashcard' | 'multiple-choice' | 'short-writing';
+  type: "flashcard" | "multiple-choice" | "short-writing";
   title: string;
   sourceText: string;
   data: FlashCard[] | MultipleChoiceQuestion[] | WritingTask[];
@@ -37,11 +37,20 @@ interface QuizContextType {
   selectedText: string;
   currentQuiz: Quiz | null;
   setSelectedText: (text: string) => void;
-  createQuiz: (type: Quiz['type'], title: string, sourceText: string, data: any[], documentId: string) => void;
-  getQuizzesByType: (type: Quiz['type']) => Quiz[];
+  createQuiz: (
+    type: Quiz["type"],
+    title: string,
+    sourceText: string,
+    data: any[],
+    documentId: string,
+  ) => void;
+  getQuizzesByType: (type: Quiz["type"]) => Quiz[];
   getQuizzesByDocument: (documentId: string) => Quiz[];
-  getQuizzesByDocumentAndType: (documentId: string, type: Quiz['type']) => Quiz[];
-  getLatestQuizByType: (type: Quiz['type']) => Quiz | null;
+  getQuizzesByDocumentAndType: (
+    documentId: string,
+    type: Quiz["type"],
+  ) => Quiz[];
+  getLatestQuizByType: (type: Quiz["type"]) => Quiz | null;
   getAllQuizzes: () => Quiz[];
   deleteQuiz: (id: string) => void;
   setCurrentQuiz: (quiz: Quiz | null) => void;
@@ -52,99 +61,111 @@ const QuizContext = createContext<QuizContextType | undefined>(undefined);
 // Mock data for demonstration
 const mockQuizzes: Quiz[] = [
   {
-    id: '1',
-    type: 'flashcard',
-    title: 'English 4 - Vocabulary',
-    sourceText: 'The ancient ruins attest to the skill of the builders.',
-    documentId: '3', // Associated with English 4 document
+    id: "1",
+    type: "flashcard",
+    title: "English 4 - Vocabulary",
+    sourceText: "The ancient ruins attest to the skill of the builders.",
+    documentId: "3", // Associated with English 4 document
     data: [
       {
-        id: '1',
-        question: 'What is the capital of Germany?',
-        answer: 'Berlin'
+        id: "1",
+        question: "What is the capital of Germany?",
+        answer: "Berlin",
       },
       {
-        id: '2',
+        id: "2",
         question: 'What does "attest" mean?',
-        answer: 'To provide or serve as clear evidence of'
+        answer: "To provide or serve as clear evidence of",
       },
       {
-        id: '3',
+        id: "3",
         question: 'What is the meaning of "ruins"?',
-        answer: 'The remains of a building that has been destroyed or damaged'
+        answer: "The remains of a building that has been destroyed or damaged",
       },
       {
-        id: '4',
+        id: "4",
         question: 'Define "ancient"',
-        answer: 'Belonging to the very distant past'
+        answer: "Belonging to the very distant past",
       },
       {
-        id: '5',
+        id: "5",
         question: 'What does "builders" refer to?',
-        answer: 'People who construct buildings or structures'
-      }
+        answer: "People who construct buildings or structures",
+      },
     ],
-    createdAt: new Date()
+    createdAt: new Date(),
   },
   {
-    id: '2',
-    type: 'multiple-choice',
-    title: 'Creative Writing Quiz',
-    sourceText: 'A writer describes a scene focusing on sensory details.',
-    documentId: '2', // Associated with English 3 document
+    id: "2",
+    type: "multiple-choice",
+    title: "Creative Writing Quiz",
+    sourceText: "A writer describes a scene focusing on sensory details.",
+    documentId: "2", // Associated with English 3 document
     data: [
       {
-        id: '1',
-        question: 'A writer describes a scene focusing on the smell of rain on hot asphalt, the taste of a salty pretzel, and the feel of a rough brick wall. What type of details are they primarily using?',
+        id: "1",
+        question:
+          "A writer describes a scene focusing on the smell of rain on hot asphalt, the taste of a salty pretzel, and the feel of a rough brick wall. What type of details are they primarily using?",
         options: [
           {
-            text: 'Sensory Details',
-            explanation: 'Correct. Sensory details appeal to the five senses (smell, taste, touch) as described in the passage.'
+            text: "Sensory Details",
+            explanation:
+              "Correct. Sensory details appeal to the five senses (smell, taste, touch) as described in the passage.",
           },
           {
-            text: 'Auditory Details',
-            explanation: 'Incorrect. While auditory details relate to sound, the passage focuses on smell, taste, and touch.'
+            text: "Auditory Details",
+            explanation:
+              "Incorrect. While auditory details relate to sound, the passage focuses on smell, taste, and touch.",
           },
           {
-            text: 'Plot Devices',
-            explanation: 'Incorrect. Plot devices are structural elements of storytelling, not descriptive details.'
+            text: "Plot Devices",
+            explanation:
+              "Incorrect. Plot devices are structural elements of storytelling, not descriptive details.",
           },
           {
-            text: 'Figurative Language',
-            explanation: 'Incorrect. Figurative language uses metaphors or similes, while this passage uses literal descriptions.'
-          }
+            text: "Figurative Language",
+            explanation:
+              "Incorrect. Figurative language uses metaphors or similes, while this passage uses literal descriptions.",
+          },
         ],
         correctAnswer: 0,
-        hint: 'Think about the five senses mentioned in the description.'
-      }
+        hint: "Think about the five senses mentioned in the description.",
+      },
     ],
-    createdAt: new Date()
+    createdAt: new Date(),
   },
   {
-    id: '3',
-    type: 'short-writing',
-    title: 'Writing Exercise',
-    sourceText: 'Practice descriptive writing techniques.',
-    documentId: '3', // Associated with English 4 document
+    id: "3",
+    type: "short-writing",
+    title: "Writing Exercise",
+    sourceText: "Practice descriptive writing techniques.",
+    documentId: "3", // Associated with English 4 document
     data: [
       {
-        id: '1',
-        title: 'Writing Task 1',
-        prompt: 'Describe your favorite place in the world and explain why it\'s special to you.',
+        id: "1",
+        title: "Writing Task 1",
+        prompt:
+          "Describe your favorite place in the world and explain why it's special to you.",
         maxWords: 150,
-        timeLimit: 10
-      }
+        timeLimit: 10,
+      },
     ],
-    createdAt: new Date()
-  }
+    createdAt: new Date(),
+  },
 ];
 
 export function QuizProvider({ children }: { children: ReactNode }) {
   const [quizzes, setQuizzes] = useState<Quiz[]>(mockQuizzes);
-  const [selectedText, setSelectedText] = useState<string>('');
+  const [selectedText, setSelectedText] = useState<string>("");
   const [currentQuiz, setCurrentQuiz] = useState<Quiz | null>(null);
 
-  const createQuiz = (type: Quiz['type'], title: string, sourceText: string, data: any[], documentId: string) => {
+  const createQuiz = (
+    type: Quiz["type"],
+    title: string,
+    sourceText: string,
+    data: any[],
+    documentId: string,
+  ) => {
     const newQuiz: Quiz = {
       id: Date.now().toString(),
       type,
@@ -152,52 +173,63 @@ export function QuizProvider({ children }: { children: ReactNode }) {
       sourceText,
       data,
       documentId,
-      createdAt: new Date()
+      createdAt: new Date(),
     };
-    setQuizzes(prev => [...prev, newQuiz]);
+    setQuizzes((prev) => [...prev, newQuiz]);
     setCurrentQuiz(newQuiz); // Set as current quiz for immediate use
   };
 
-  const getQuizzesByType = (type: Quiz['type']) => {
-    return quizzes.filter(quiz => quiz.type === type);
+  const getQuizzesByType = (type: Quiz["type"]) => {
+    return quizzes.filter((quiz) => quiz.type === type);
   };
 
   const getQuizzesByDocument = (documentId: string) => {
-    return quizzes.filter(quiz => quiz.documentId === documentId).sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    return quizzes
+      .filter((quiz) => quiz.documentId === documentId)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   };
 
-  const getQuizzesByDocumentAndType = (documentId: string, type: Quiz['type']) => {
-    return quizzes.filter(quiz => quiz.documentId === documentId && quiz.type === type).sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+  const getQuizzesByDocumentAndType = (
+    documentId: string,
+    type: Quiz["type"],
+  ) => {
+    return quizzes
+      .filter((quiz) => quiz.documentId === documentId && quiz.type === type)
+      .sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
   };
 
-  const getLatestQuizByType = (type: Quiz['type']) => {
-    const typeQuizzes = quizzes.filter(quiz => quiz.type === type);
+  const getLatestQuizByType = (type: Quiz["type"]) => {
+    const typeQuizzes = quizzes.filter((quiz) => quiz.type === type);
     return typeQuizzes.length > 0 ? typeQuizzes[typeQuizzes.length - 1] : null;
   };
 
   const getAllQuizzes = () => {
-    return quizzes.sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime());
+    return quizzes.sort(
+      (a, b) => b.createdAt.getTime() - a.createdAt.getTime(),
+    );
   };
 
   const deleteQuiz = (id: string) => {
-    setQuizzes(prev => prev.filter(quiz => quiz.id !== id));
+    setQuizzes((prev) => prev.filter((quiz) => quiz.id !== id));
   };
 
   return (
-    <QuizContext.Provider value={{
-      quizzes,
-      selectedText,
-      currentQuiz,
-      setSelectedText,
-      createQuiz,
-      getQuizzesByType,
-      getQuizzesByDocument,
-      getQuizzesByDocumentAndType,
-      getLatestQuizByType,
-      getAllQuizzes,
-      deleteQuiz,
-      setCurrentQuiz
-    }}>
+    <QuizContext.Provider
+      value={{
+        quizzes,
+        selectedText,
+        currentQuiz,
+        setSelectedText,
+        createQuiz,
+        getQuizzesByType,
+        getQuizzesByDocument,
+        getQuizzesByDocumentAndType,
+        getLatestQuizByType,
+        getAllQuizzes,
+        deleteQuiz,
+        setCurrentQuiz,
+      }}
+    >
       {children}
     </QuizContext.Provider>
   );
@@ -206,7 +238,7 @@ export function QuizProvider({ children }: { children: ReactNode }) {
 export function useQuiz() {
   const context = useContext(QuizContext);
   if (context === undefined) {
-    throw new Error('useQuiz must be used within a QuizProvider');
+    throw new Error("useQuiz must be used within a QuizProvider");
   }
   return context;
 }

--- a/client/global.css
+++ b/client/global.css
@@ -102,5 +102,40 @@
 
   body {
     @apply bg-background text-foreground;
+    /* Mobile optimizations */
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    touch-action: manipulation;
+    overscroll-behavior: none;
+  }
+
+  /* Mobile touch improvements */
+  @media (hover: none) and (pointer: coarse) {
+    button:hover {
+      background-color: initial;
+    }
+  }
+
+  /* Prevent zoom on input focus on iOS */
+  input[type="text"],
+  input[type="email"],
+  input[type="password"],
+  textarea,
+  select {
+    font-size: 16px;
+  }
+
+  /* Custom scrollbars for mobile */
+  ::-webkit-scrollbar {
+    width: 2px;
+  }
+
+  ::-webkit-scrollbar-track {
+    background: transparent;
+  }
+
+  ::-webkit-scrollbar-thumb {
+    background: rgba(0, 0, 0, 0.2);
+    border-radius: 1px;
   }
 }

--- a/client/pages/Index.tsx
+++ b/client/pages/Index.tsx
@@ -1,5 +1,5 @@
-import EditorLayout from "../components/EditorLayoutSimple";
+import MobileEditorLayout from "../components/MobileEditorLayout";
 
 export default function Index() {
-  return <EditorLayout />;
+  return <MobileEditorLayout />;
 }

--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no"
+    />
     <meta name="apple-mobile-web-app-capable" content="yes" />
     <meta name="apple-mobile-web-app-status-bar-style" content="default" />
     <meta name="theme-color" content="#ffffff" />

--- a/index.html
+++ b/index.html
@@ -2,8 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Hello world project</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="default" />
+    <meta name="theme-color" content="#ffffff" />
+    <title>StudyNotes - Mobile Learning Assistant</title>
   </head>
 
   <body>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,7 +152,7 @@ importers:
         version: 0.176.0
       '@vitejs/plugin-react-swc':
         specifier: ^4.0.0
-        version: 4.0.0(vite@7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1))
+        version: 4.0.0(vite@7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1))
       autoprefixer:
         specifier: ^10.4.21
         version: 10.4.21(postcss@8.5.6)
@@ -244,8 +244,8 @@ importers:
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       vite:
-        specifier: ^7.1.2
-        version: 7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
+        specifier: ^7.1.3
+        version: 7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
@@ -1998,6 +1998,15 @@ packages:
       picomatch:
         optional: true
 
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
   fflate@0.6.10:
     resolution: {integrity: sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==}
 
@@ -3260,8 +3269,8 @@ packages:
     engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
     hasBin: true
 
-  vite@7.1.2:
-    resolution: {integrity: sha512-J0SQBPlQiEXAF7tajiH+rUooJPo0l8KQgyg4/aMunNtrOa7bwuZJsJbDWzeljqQpgftxuq5yNJxQ91O9ts29UQ==}
+  vite@7.1.3:
+    resolution: {integrity: sha512-OOUi5zjkDxYrKhTV3V7iKsoS37VUM7v40+HuwEmcrsf11Cdx9y3DIr2Px6liIcZFwt3XSRpQvFpL3WVy7ApkGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
@@ -4652,11 +4661,11 @@ snapshots:
       '@use-gesture/core': 10.3.1
       react: 18.3.1
 
-  '@vitejs/plugin-react-swc@4.0.0(vite@7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1))':
+  '@vitejs/plugin-react-swc@4.0.0(vite@7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-beta.30
       '@swc/core': 1.13.3
-      vite: 7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
+      vite: 7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -4668,13 +4677,13 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
+      vite: 7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -5128,6 +5137,10 @@ snapshots:
       reusify: 1.1.0
 
   fdir@6.4.6(picomatch@4.0.3):
+    optionalDependencies:
+      picomatch: 4.0.3
+
+  fdir@6.5.0(picomatch@4.0.3):
     optionalDependencies:
       picomatch: 4.0.3
 
@@ -6821,7 +6834,7 @@ snapshots:
       debug: 4.4.1
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
+      vite: 7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6836,10 +6849,10 @@ snapshots:
       - tsx
       - yaml
 
-  vite@7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1):
+  vite@7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.8
-      fdir: 6.4.6(picomatch@4.0.3)
+      fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
       postcss: 8.5.6
       rollup: 4.46.2
@@ -6855,7 +6868,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -6873,7 +6886,7 @@ snapshots:
       tinyglobby: 0.2.14
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.2(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
+      vite: 7.1.3(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
       vite-node: 3.2.4(@types/node@24.2.1)(jiti@1.21.7)(tsx@4.20.3)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:


### PR DESCRIPTION
## Purpose

Based on the conversation history, the user requested:
- Title editing functionality positioned at the big title location (similar to Obsidian)
- Font preservation during title editing without changes
- Duplicate title validation that prevents saving and shows a red warning box below the title
- A simple red notification box instead of a popup for duplicate warnings

## Code changes

- **Added new MobileEditorLayout component** with comprehensive mobile-optimized editor functionality
- **Implemented title editing with validation**:
  - In-place title editing that preserves font styling
  - Duplicate title detection across all documents
  - Red warning display below title when duplicates are detected
  - Prevents saving when title already exists
- **Enhanced QuizContext** with `getAllQuizzes()` method for better quiz management
- **Mobile optimizations**:
  - Touch-friendly interactions and scrolling
  - Viewport meta tags for proper mobile rendering
  - CSS improvements for mobile devices
  - Font smoothing and touch action optimizations
- **Updated main entry point** to use the new mobile editor layout
- **Package updates** including Vite version bump for better performance

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 6`

🔗 [Edit in Builder.io](https://builder.io/app/projects/9c537c2e356447d0a106ace6679df92c/nova-oasis)

👀 [Preview Link](https://9c537c2e356447d0a106ace6679df92c-nova-oasis.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>9c537c2e356447d0a106ace6679df92c</projectId>-->
<!--<branchName>nova-oasis</branchName>-->